### PR TITLE
ブログポストのエントリページからDISQUSコメントを削除

### DIFF
--- a/_layouts/_haml/post.haml
+++ b/_layouts/_haml/post.haml
@@ -5,24 +5,3 @@ layout: default
   %h1 {{ page.title }}
   %p.meta {{ page.date | date_to_string }} by {{ page.author }}
   {{ content }}
-
-  #disqus_thread
-  :javascript
-    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-    var disqus_shortname = 'crystal-lang'; // required: replace example with your forum shortname
-    var disqus_identifier = '{{ page.id }}';
-    var disqus_title = "{{ page.title }}";
-    var disqus_url = "http://crystal-lang.org/{{ page.url }}";
-
-    /* * * DON'T EDIT BELOW THIS LINE * * */
-    (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    })();
-  %noscript
-    Please enable JavaScript to view the
-    %a{href: "http://disqus.com/?ref_noscript"} comments powered by Disqus.
-  %a.dsq-brlink{href: "http://disqus.com"}
-    comments powered by
-    %span.logo-disqus Disqus

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,27 +5,4 @@ layout: default
   <h1>{{ page.title }}</h1>
   <p class='meta'>{{ page.date | date_to_string }} by {{ page.author }}</p>
   {{ content }}
-  <div id='disqus_thread'></div>
-  <script>
-    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-    var disqus_shortname = 'crystal-lang'; // required: replace example with your forum shortname
-    var disqus_identifier = '{{ page.id }}';
-    var disqus_title = "{{ page.title }}";
-    var disqus_url = "http://crystal-lang.org/{{ page.url }}";
-    
-    /* * * DON'T EDIT BELOW THIS LINE * * */
-    (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    })();
-  </script>
-  <noscript>
-    Please enable JavaScript to view the
-    <a href='http://disqus.com/?ref_noscript'>comments powered by Disqus.</a>
-  </noscript>
-  <a class='dsq-brlink' href='http://disqus.com'>
-    comments powered by
-    <span class='logo-disqus'>Disqus</span>
-  </a>
 </section>


### PR DESCRIPTION
ブログポストのエントリページにDISQUSのコメントがあるのですが、埋め込みスクリプトが本家サイトそのままなので本家サイトのコメントが表示されています。
誤って投稿などしてしまうと微妙なので一旦該当箇所をざっくり削除しました。
