### PR TITLE
Install specific version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ cache:
     - $HOME/.npm
 before_install:
   - . $HOME/.nvm/nvm.sh
-  - nvm install stable
-  - nvm use stable
+  - nvm install 6.10
+  - nvm use 6.10
   - npm install -g gitbook-cli
   - bundle install --deployment --jobs=3 --retry=3
 script: test $TRAVIS_PULL_REQUEST != "false" || test $TRAVIS_BRANCH != "gh-pages" || ./travis-build.sh


### PR DESCRIPTION
```
Error loading version latest: Error: Cannot find module 'internal/fs'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at evalmachine.<anonymous>:40:20
    at Object.<anonymous> (/home/travis/.gitbook/versions/2.3.2/node_modules/graceful-fs/fs.js:11:1)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
```

のエラー対策