### PR TITLE
"Revert "Add gitbook warning plugin"" のリバート

### DIFF
--- a/_gitbook/book.json
+++ b/_gitbook/book.json
@@ -1,5 +1,8 @@
 {
     "links": {
         "contributePrefix": "https://github.com/manastech/crystal/edit/gh-pages/_gitbook/"
-    }
+    },
+    "plugins": [
+        "additionalinfo@git+https://github.com/5t111111/gitbook-plugin-additionalinfo.git"
+    ]
 }


### PR DESCRIPTION
Reverts crystal-jp/ja.crystal-lang.org#78

エラー原因はこの対応と全く別原因だったのでリバートをリバートします。