### PR TITLE
ブログポストを翻訳対象ファイルに追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TRANSLATE_FILES := \
     /crystal-website/_includes/install_from_*.md \
     /crystal-website/_layouts/default.html \
     /crystal-website/_layouts/install.html \
-    /crystal-website/_posts/2020-06-09-crystal-0.35.0-released.md \
+    /crystal-website/_posts/*.md \
     /crystal-website/blog/index.html \
     /crystal-website/community/index.html \
     /crystal-website/docs.html \


### PR DESCRIPTION
0.35.0リリースノート以外のポストが翻訳対象に上がってこなかったので。