### PR TITLE
fix(website): typo

### DIFF
--- a/i18n/omegat/project_save.tmx
+++ b/i18n/omegat/project_save.tmx
@@ -13065,8 +13065,8 @@ second operand with pattern matching.</seg>
       <tuv lang="EN-US">
         <seg>&lt;g1&gt;Read more about Crystal's type system&lt;/g1&gt;</seg>
       </tuv>
-      <tuv lang="JA" changeid="makenowjust" changedate="20200518T072620Z" creationid="makenowjust" creationdate="20200518T072609Z">
-        <seg>&lt;g1&gt;Crystal の方システムについて、より詳しく見る&lt;/g1&gt;</seg>
+      <tuv lang="JA" changeid="nsfisis" changedate="20201127T203223Z" creationid="makenowjust" creationdate="20200518T072609Z">
+        <seg>&lt;g1&gt;Crystal の型システムについて、より詳しく見る&lt;/g1&gt;</seg>
       </tuv>
     </tu>
     <tu>

--- a/locale/ja/crystal-website/index.html
+++ b/locale/ja/crystal-website/index.html
@@ -34,7 +34,7 @@ custom_body_classes:
       <h2>型システム</h2>
       <p>Crystal は静的に型チェックされるプログラミング言語です。そのため、実行時にエラーを起こすのではなく、コンパイラが早期に型エラーを発見するでしょう。さらに、Crystal は型推論も備えています。ほとんどの場合、型注釈は必要ありません。</p>
       <div class="code_section">{% include sample_type_system.md %}</div>
-      <p class="read-more"><a href="https://ja.crystal-lang.org/reference/syntax_and_semantics/types_and_methods.html">Crystal の方システムについて、より詳しく見る</a></p>
+      <p class="read-more"><a href="https://ja.crystal-lang.org/reference/syntax_and_semantics/types_and_methods.html">Crystal の型システムについて、より詳しく見る</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
漢字のタイポ修正です。「方システム」→「型システム」

ページ https://ja.crystal-lang.org/ における以下スクリーンショット部分になります。

![image](https://user-images.githubusercontent.com/54318333/100483718-38c2f900-313d-11eb-90b8-7c9990b87d12.png)
