### PR TITLE
Fix getting-started/cli.md

### DIFF
--- a/i18n/omegat/project_save.tmx
+++ b/i18n/omegat/project_save.tmx
@@ -249,6 +249,58 @@ option_parser = OptionParser.parse do |parser|</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
+        <seg>"Ringo Starr",
+]
+say_hi_to = ""
+
+option_parser = OptionParser.parse do |parser|</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T085143Z" creationid="makenowjust" creationdate="20211107T085143Z">
+        <seg>"Ringo Starr",
+]
+say_hi_to = ""
+
+option_parser = OptionParser.parse do |parser|</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>"Ringo Starr",
+]
+shout = false
+
+option_parser = OptionParser.parse do |parser|</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T085139Z" creationid="makenowjust" creationdate="20211107T085139Z">
+        <seg>"Ringo Starr",
+]
+shout = false
+
+option_parser = OptionParser.parse do |parser|</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>"Ringo Starr",
+]
+shout = false
+say_hi_to = ""
+strawberry = false
+
+option_parser = OptionParser.parse do |parser|</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T085507Z" creationid="makenowjust" creationdate="20211107T085507Z">
+        <seg>"Ringo Starr",
+]
+shout = false
+say_hi_to = ""
+strawberry = false
+
+option_parser = OptionParser.parse do |parser|</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
         <seg>"USD" =&gt; 1.12,</seg>
       </tuv>
       <tuv lang="JA" changeid="hirofumiwakasugi" changedate="20151010T012156Z" creationid="hirofumiwakasugi" creationdate="20151010T012156Z">
@@ -6710,6 +6762,18 @@ You say goodbye, and Ringo Starr say hello to Penny Lane!</seg>
         <seg>$ crystal run ./hello_goodbye.cr -- -g "Penny Lane"
 
 You say goodbye, and Ringo Starr say hello to Penny Lane!</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>$ crystal run ./hello_goodbye.cr -- -g "Penny Lane"
+
+You say goodbye, and Ringo Starr says hello to Penny Lane!</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T085309Z" creationid="makenowjust" creationdate="20211107T085309Z">
+        <seg>$ crystal run ./hello_goodbye.cr -- -g "Penny Lane"
+
+You say goodbye, and Ringo Starr says hello to Penny Lane!</seg>
       </tuv>
     </tu>
     <tu>
@@ -16030,6 +16094,14 @@ second operand with pattern matching.</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
+        <seg>&lt;g3&gt;Readline&lt;/g3&gt; has some great features: filename autocompletion out of the box; custom auto-completion method; keybinding, just to mention a few.</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091141Z" creationid="makenowjust" creationdate="20211107T091141Z">
+        <seg>&lt;g3&gt;Readline&lt;/g3&gt; は素晴らしく強力な機能があります。ボックス外でのファイル名の自動補完、自動補完方法のカスタマイズ、キーバインド変更というのはほんの一例です。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
         <seg>&lt;g3&gt;Readline&lt;/g3&gt; has some great features: filename autocompletion out of the box; custom autocompletion method; keybinding, just to mention a few.</seg>
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200413T190259Z" creationid="makenowjust" creationdate="20200413T190259Z">
@@ -20416,6 +20488,14 @@ foo(String) # =&gt; Array(String)</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
+        <seg>As with any other application, at some point, we would like to &lt;g1&gt;write tests&lt;/g1&gt; for the different features.</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091057Z" creationid="makenowjust" creationdate="20211107T091057Z">
+        <seg>他のアプリケーションと同じように、ある時点で、さまざまな機能の&lt;g1&gt;テストを書き&lt;/g1&gt;たいと思うでしょう。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
         <seg>As with other keg-only formulas there are some caveats shown in &lt;g1&gt;brew info &lt;formula&gt;&lt;/g1&gt; that shows how to link &lt;g2&gt;pkg-config&lt;/g2&gt; with this library.</seg>
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200518T112255Z" creationid="makenowjust" creationdate="20200518T112255Z">
@@ -20651,6 +20731,14 @@ end
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200809T110235Z" creationid="makenowjust" creationdate="20200809T110235Z">
         <seg>同時に、&lt;g1&gt;--ignore-crystal-version&lt;/g1&gt; が追加され、このチェックを無視できるようにもなっています。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>At the start our CLI application has two options:</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T085133Z" creationid="makenowjust" creationdate="20211107T085133Z">
+        <seg>まずは次の2つのオプションを持つCLIアプリケーションです:</seg>
       </tuv>
     </tu>
     <tu>
@@ -21460,6 +21548,14 @@ end
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200413T182132Z" creationid="makenowjust" creationdate="20200413T182132Z">
         <seg>しかし、ここでユーザーが何も入力しなかったらどうなるのでしょう？　</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>But what happens if the user doesn’t enter any value?</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T085952Z" creationid="makenowjust" creationdate="20211107T085952Z">
+        <seg>しかし、ユーザーが何も入力しなかった場合はどうなるでしょうか？　</seg>
       </tuv>
     </tu>
     <tu>
@@ -28764,6 +28860,14 @@ entrypoints for the docs generator.</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
+        <seg>In that case, we would get an empty string (if the user only presses &lt;g1&gt;Enter&lt;/g1&gt;) or maybe a &lt;g2&gt;Nil&lt;/g2&gt; value (if the input stream is closed, e.g. by pressing &lt;g3&gt;Ctrl+D&lt;/g3&gt;).</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T090847Z" creationid="makenowjust" creationdate="20211107T090301Z">
+        <seg>この場合、空の文字列 (ユーザーが &lt;g1&gt;Enter&lt;/g1&gt; だけ入力した場合) か、&lt;g2&gt;Nil&lt;/g2&gt; 値 (インプットがクローズされた場合、例えば &lt;g3&gt;Ctrl+D&lt;/g3&gt; を押された) を取得します。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
         <seg>In the "Everything is an object" section we said that an object has a type and responds to some methods, which is the only way to interact with objects, so we'll need a `name` and `age` methods.</seg>
       </tuv>
       <tuv lang="JA" changeid="hirofumiwakasugi" changedate="20150904T061750Z" creationid="hirofumiwakasugi" creationdate="20150904T052518Z">
@@ -33201,6 +33305,14 @@ specifying the current working directory.</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
+        <seg>Once the refactoring is done, we could start testing the logic and including the file with the logic in the testing files we need.</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091112Z" creationid="makenowjust" creationdate="20211107T091112Z">
+        <seg>リファクタリングが完了したら、ロジックのテストを開始し、必要なテストファイルにロジックを含むファイルを含めることができます。これは読者の課題としましょう。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
         <seg>Once the repository is configured you're ready to install Crystal:</seg>
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200518T101752Z" creationid="makenowjust" creationdate="20200518T101752Z">
@@ -36074,6 +36186,14 @@ recursively forms a union type out of nested type paramters:</seg>
       </tuv>
       <tuv lang="JA" changeid="hirofumiwakasugi" changedate="20150908T013634Z" creationid="hirofumiwakasugi" creationdate="20150908T013205Z">
         <seg>したがって、通常は型制約を使わず、メソッドをオーバーロードするときにのみ使用するくらいが好ましいでしょう。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>So, let's add this option handler and merge all these CLI applications into one fabulous CLI application!</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T085337Z" creationid="makenowjust" creationdate="20211107T085337Z">
+        <seg>それでは、これらのオプションハンドラーを追加して、すべてを1つのすばらしいCLIアプリケーションにマージしましょう。</seg>
       </tuv>
     </tu>
     <tu>
@@ -39355,6 +39475,14 @@ a `def` without a matching `end`, or a single `when` expression of a
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200413T182042Z" creationid="makenowjust" creationdate="20200413T182025Z">
         <seg> &lt;g1&gt;&lt;g2&gt;gets&lt;/g2&gt;&lt;/g1&gt;メソッドはアプリケーションの実行を、ユーザーの入力が終了する (&lt;g4&gt;Enter&lt;/g4&gt;が押される) まで&lt;g3&gt;停止&lt;/g3&gt;させます。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>The method &lt;g1&gt;&lt;g2&gt;gets&lt;/g2&gt;&lt;/g1&gt;https://crystal-lang.org/api/latest/toplevel.html#gets%28*args,**options%29-class-method&lt;e7/&gt; will &lt;g3&gt;pause&lt;/g3&gt; the execution of the application until the user finishes entering the input (pressing the &lt;g4&gt;Enter&lt;/g4&gt; key).</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T090042Z" creationid="makenowjust" creationdate="20211107T085638Z">
+        <seg>メソッド &lt;g1&gt;&lt;g2&gt;gets&lt;/g2&gt;&lt;/g1&gt;https://crystal-lang.org/api/latest/toplevel.html#gets%28*args,**options%29-class-method&lt;e7/&gt; は、ユーザーが入力を完了する (&lt;g4&gt;Enter&lt;/g4&gt; キーを押す) まで、アプリケーションの実行を&lt;g3&gt;一時停止&lt;/g3&gt;します。</seg>
       </tuv>
     </tu>
     <tu>
@@ -43512,6 +43640,14 @@ by joining multiple literals with a backslash:</seg>
     </tu>
     <tu>
       <tuv lang="EN-US">
+        <seg>To illustrate the problem let’s try the following: we want the input entered by the user to be sung loudly:</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T090944Z" creationid="makenowjust" creationdate="20211107T090944Z">
+        <seg>この場合の問題を説明するために次のようにしてみましょう。ユーザーが入力した文字を大文字にしてみます:</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
         <seg>To install from source, download or clone &lt;g1&gt;the repository&lt;/g1&gt; and run &lt;g2&gt;make CRFLAGS=--release&lt;/g2&gt;.</seg>
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200419T173505Z" creationid="makenowjust" creationdate="20200419T173505Z">
@@ -45767,6 +45903,14 @@ included modules as well:</seg>
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20200427T103026Z" creationid="makenowjust" creationdate="20200427T103026Z">
         <seg>そして、これらの情報は&lt;g5&gt;アットマーク記号&lt;/g5&gt; (&lt;g6&gt;@&lt;/g6&gt;) が先頭についたインスタンス変数に格納します。</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>We will use a yellow font on a black background:</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091015Z" creationid="makenowjust" creationdate="20211107T091015Z">
+        <seg>黒の背景に黄色のフォントを使用します:</seg>
       </tuv>
     </tu>
     <tu>
@@ -64784,10 +64928,10 @@ end
 ```crystal
 require "option_parser"</seg>
       </tuv>
-      <tuv lang="JA" changeid="makenowjust" changedate="20210324T100604Z" creationid="makenowjust" creationdate="20210324T100604Z">
-        <seg>example "all_my_cli.cr"
-```crystal
-require "option_parser"</seg>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091551Z" creationid="makenowjust" creationdate="20210324T100604Z">
+        <seg> example "all_my_cli.cr"
+    ```crystal
+    require "option_parser"</seg>
       </tuv>
     </tu>
     <tu>
@@ -64808,10 +64952,10 @@ require "benchmark"</seg>
 ```crystal
 require "option_parser"</seg>
       </tuv>
-      <tuv lang="JA" changeid="makenowjust" changedate="20210324T100559Z" creationid="makenowjust" creationdate="20210324T100559Z">
-        <seg>example "hello_goodbye.cr"
-```crystal
-require "option_parser"</seg>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091543Z" creationid="makenowjust" creationdate="20210324T100559Z">
+        <seg> example "hello_goodbye.cr"
+    ```crystal
+    require "option_parser"</seg>
       </tuv>
     </tu>
     <tu>
@@ -64834,10 +64978,10 @@ puts "Hello World!"
 ```crystal
 require "option_parser"</seg>
       </tuv>
-      <tuv lang="JA" changeid="makenowjust" changedate="20210324T100517Z" creationid="makenowjust" creationdate="20210324T100517Z">
-        <seg>example "help.cr"
-```crystal
-require "option_parser"</seg>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091433Z" creationid="makenowjust" creationdate="20210324T100517Z">
+        <seg> example "help.cr"
+    ```crystal
+    require "option_parser"</seg>
       </tuv>
     </tu>
     <tu>
@@ -64887,6 +65031,50 @@ puts "The Beatles are singing: 🎵#{user_input}🎶🎸🥁"
     <tu>
       <tuv lang="EN-US">
         <seg>example "let_it_cli.cr"
+&lt;g1&gt;crystal
+puts "Welcome to The Beatles Sing-Along version 1.0!"
+puts "Enter a phrase you want The Beatles to sing"
+print "&gt; "
+user_input = gets
+puts "The Beatles are singing: 🎵#{user_input.upcase}🎶🎸🥁"
+&lt;/g1&gt;</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091646Z" creationid="makenowjust" creationdate="20211107T090946Z">
+        <seg> example "let_it_cli.cr"
+    &lt;g1&gt;crystal
+    puts "Welcome to The Beatles Sing-Along version 1.0!"
+    puts "Enter a phrase you want The Beatles to sing"
+    print "&gt; "
+    user_input = gets
+    puts "The Beatles are singing: 🎵#{user_input.upcase}🎶🎸🥁"
+    &lt;/g1&gt;</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>example "let_it_cli.cr"
+&lt;g1&gt;crystal
+puts "Welcome to The Beatles Sing-Along version 1.0!"
+puts "Enter a phrase you want The Beatles to sing"
+print "&gt; "
+user_input = gets
+puts "The Beatles are singing: 🎵#{user_input}🎶🎸🥁"
+&lt;/g1&gt;</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091608Z" creationid="makenowjust" creationdate="20211107T085517Z">
+        <seg> example "let_it_cli.cr"
+    &lt;g1&gt;crystal
+    puts "Welcome to The Beatles Sing-Along version 1.0!"
+    puts "Enter a phrase you want The Beatles to sing"
+    print "&gt; "
+    user_input = gets
+    puts "The Beatles are singing: 🎵#{user_input}🎶🎸🥁"
+    &lt;/g1&gt;</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>example "let_it_cli.cr"
 ```crystal
 puts "Welcome to The Beatles Sing Along version 1.0!"
 puts "Enter a phrase you want The Beatles to sing"
@@ -64906,12 +65094,30 @@ user_input = gets</seg>
       <tuv lang="EN-US">
         <seg>example "let_it_cli.cr"
 ```crystal
-require "colorize"</seg>
+puts "Welcome to The Beatles Sing-Along version 1.0!"
+puts "Enter a phrase you want The Beatles to sing"
+print "&gt; "
+user_input = gets</seg>
       </tuv>
-      <tuv lang="JA" changeid="makenowjust" changedate="20210324T100625Z" creationid="makenowjust" creationdate="20210324T100625Z">
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091657Z" creationid="makenowjust" creationdate="20211107T091000Z">
+        <seg> example "let_it_cli.cr"
+    ```crystal
+    puts "Welcome to The Beatles Sing-Along version 1.0!"
+    puts "Enter a phrase you want The Beatles to sing"
+    print "&gt; "
+    user_input = gets</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
         <seg>example "let_it_cli.cr"
 ```crystal
 require "colorize"</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091710Z" creationid="makenowjust" creationdate="20210324T100625Z">
+        <seg> example "let_it_cli.cr"
+    ```crystal
+    require "colorize"</seg>
       </tuv>
     </tu>
     <tu>
@@ -64970,10 +65176,10 @@ require "../src/project"
 ```crystal
 require "option_parser"</seg>
       </tuv>
-      <tuv lang="JA" changeid="makenowjust" changedate="20210324T100523Z" creationid="makenowjust" creationdate="20210324T100523Z">
-        <seg>example "twist_and_shout.cr"
-```crystal
-require "option_parser"</seg>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091441Z" creationid="makenowjust" creationdate="20210324T100523Z">
+        <seg> example "twist_and_shout.cr"
+    ```crystal
+    require "option_parser"</seg>
       </tuv>
     </tu>
     <tu>
@@ -64986,6 +65192,18 @@ require "./one"</seg>
         <seg>example "two.cr"
 ```crystal
 require "./one"</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>example "yellow_cli.cr"
+```crystal
+require "colorize"</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091704Z" creationid="makenowjust" creationdate="20211107T091016Z">
+        <seg> example "yellow_cli.cr"
+    ```crystal
+    require "colorize"</seg>
       </tuv>
     </tu>
     <tu>
@@ -71217,6 +71435,24 @@ exit if user_input.nil?</seg>
       </tuv>
       <tuv lang="JA" changeid="makenowjust" changedate="20210324T100627Z" creationid="makenowjust" creationdate="20210324T100627Z">
         <seg>puts "Welcome to The Beatles Sing Along version 1.0!"
+puts "Enter a phrase you want The Beatles to sing"
+print "&gt; "
+user_input = gets
+
+exit if user_input.nil?</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv lang="EN-US">
+        <seg>puts "Welcome to The Beatles Sing-Along version 1.0!"
+puts "Enter a phrase you want The Beatles to sing"
+print "&gt; "
+user_input = gets
+
+exit if user_input.nil?</seg>
+      </tuv>
+      <tuv lang="JA" changeid="makenowjust" changedate="20211107T091021Z" creationid="makenowjust" creationdate="20211107T091021Z">
+        <seg>puts "Welcome to The Beatles Sing-Along version 1.0!"
 puts "Enter a phrase you want The Beatles to sing"
 print "&gt; "
 user_input = gets

--- a/locale/ja/crystal-book/docs/getting_started/cli.md
+++ b/locale/ja/crystal-book/docs/getting_started/cli.md
@@ -27,14 +27,14 @@ $ crystal -v
 
 ここで「**オプションの解析部分を実装する必要がある？**」と疑問を持つことでしょう。その必要はありません。Crystal では`OptionParser`がその機能を提供しています。それではこのパーサーを使ったアプリケーションを作ってみましょう。
 
-At the start our CLI application has two options:
+まずは次の2つのオプションを持つCLIアプリケーションです:
 
 * `-v` / `--version`: アプリケーションのバージョンを表示する。
 * `-h` / `--help`: アプリケーションの利用方法を表示する。
 
-!!!example "help.cr"
-```crystal
-require "option_parser"
+!!! example "help.cr"
+    ```crystal
+    require "option_parser"
 
     OptionParser.parse do |parser|
       parser.banner = "Welcome to The Beatles App!"
@@ -74,9 +74,9 @@ Welcome to The Beatles App!
 
 デフォルトでは (オプションが与えられなかったときに) The Fab Four のメンバーを表示します。しかし、`-t` もしくは `--twist` が渡されたときには、名前を大文字にします。
 
-!!!example "twist_and_shout.cr"
-```crystal
-require "option_parser"
+!!! example "twist_and_shout.cr"
+    ```crystal
+    require "option_parser"
 
     the_beatles = [
       "John Lennon",
@@ -130,9 +130,9 @@ require "option_parser"
 
 次はこんなアプリケーションを作ってみましょう。_`-g` / `--goodbye_hello`オプションが与えられたときに、**オプションのパラメーター**として渡された名前に挨拶をする_。
 
-!!!example "hello_goodbye.cr"
-```crystal
-require "option_parser"
+!!! example "hello_goodbye.cr"
+    ```crystal
+    require "option_parser"
 
     the_beatles = [
       "John Lennon",
@@ -184,15 +184,15 @@ Unhandled exception: Invalid option: -n (OptionParser::InvalidOption)
 
 なんてことでしょう。これは壊れていますね。**無効なオプション**と**無効なパラメーター**が渡されたときの処理をする必要するがあります。2つの状況に応じて、`OptionParser`クラスは`#invalid_option`と`#missing_option`という2つメソッドを持っています。
 
-So, let's add this option handler and merge all these CLI applications into one fabulous CLI application!
+それでは、これらのオプションハンドラーを追加して、すべてを1つのすばらしいCLIアプリケーションにマージしましょう。
 
 #### All My CLI: 完成した CLI アプリケーション
 
 これが、無効なオプション/パラメーターの処理を追加して、新しいオプションを追加した、最終的なソースコードです。
 
-!!!example "all_my_cli.cr"
-```crystal
-require "option_parser"
+!!! example "all_my_cli.cr"
+    ```crystal
+    require "option_parser"
 
     the_beatles = [
       "John Lennon",
@@ -263,29 +263,29 @@ require "option_parser"
 しばしばユーザーに値を入力してもらいたい場合があります。どのようにして値を_読む_のでしょうか？　
 簡単です！The Fab Four が望むフレーズを唄ってくれる、というアプリケーションを作ってみましょう。このアプリケーションを実行すると、ユーザーにフレーズを要求して、そして魔法が起こります！
 
-!!!example "let_it_cli.cr"
-```crystal
-puts "Welcome to The Beatles Sing-Along version 1.0!"
-puts "Enter a phrase you want The Beatles to sing"
-print "> "
-user_input = gets
-puts "The Beatles are singing: 🎵#{user_input}🎶🎸🥁"
-```
+!!! example "let_it_cli.cr"
+    ```crystal
+    puts "Welcome to The Beatles Sing-Along version 1.0!"
+    puts "Enter a phrase you want The Beatles to sing"
+    print "> "
+    user_input = gets
+    puts "The Beatles are singing: 🎵#{user_input}🎶🎸🥁"
+    ```
 
-The method [`gets`](https://crystal-lang.org/api/latest/toplevel.html#gets%28*args,**options%29-class-method) will **pause** the execution of the application until the user finishes entering the input (pressing the `Enter` key).
+メソッド [`gets`](https://crystal-lang.org/api/latest/toplevel.html#gets%28*args,**options%29-class-method) は、ユーザーが入力を完了する (`Enter` キーを押す) まで、アプリケーションの実行を**一時停止**します。
 ユーザーが`Enter`を押すと、実行が再開して`user_input`にユーザーの入力した値が入ります。
 
-But what happens if the user doesn’t enter any value? In that case, we would get an empty string (if the user only presses `Enter`) or maybe a `Nil` value (if the input stream is closed, e.g. by pressing `Ctrl+D`).
-To illustrate the problem let’s try the following: we want the input entered by the user to be sung loudly:
+しかし、ユーザーが何も入力しなかった場合はどうなるでしょうか？　この場合、空の文字列 (ユーザーが `Enter` だけ入力した場合) か、`Nil` 値 (インプットがクローズされた場合、例えば `Ctrl+D` を押された) を取得します。
+この場合の問題を説明するために次のようにしてみましょう。ユーザーが入力した文字を大文字にしてみます:
 
-!!!example "let_it_cli.cr"
-```crystal
-puts "Welcome to The Beatles Sing-Along version 1.0!"
-puts "Enter a phrase you want The Beatles to sing"
-print "> "
-user_input = gets
-puts "The Beatles are singing: 🎵#{user_input.upcase}🎶🎸🥁"
-```
+!!! example "let_it_cli.cr"
+    ```crystal
+    puts "Welcome to The Beatles Sing-Along version 1.0!"
+    puts "Enter a phrase you want The Beatles to sing"
+    print "> "
+    user_input = gets
+    puts "The Beatles are singing: 🎵#{user_input.upcase}🎶🎸🥁"
+    ```
 
 これを実行しようとしてみると、 Crystal はこんな風にしてコンパイルに失敗するでしょう。
 
@@ -303,12 +303,12 @@ Error: undefined method 'upper_case' for Nil (compile-time type is (String | Nil
 つまり、こういうことです。ユーザーの入力した値の型は`String | Nil`という[ユニオン型](../syntax_and_semantics/type_grammar.md)なのです。
 というわけで、`Nil`もしくは`""` (空文字列) かをチェックして、自然に動作するようにしましょう。
 
-!!!example "let_it_cli.cr"
-```crystal
-puts "Welcome to The Beatles Sing-Along version 1.0!"
-puts "Enter a phrase you want The Beatles to sing"
-print "> "
-user_input = gets
+!!! example "let_it_cli.cr"
+    ```crystal
+    puts "Welcome to The Beatles Sing-Along version 1.0!"
+    puts "Enter a phrase you want The Beatles to sing"
+    print "> "
+    user_input = gets
 
     exit if user_input.nil?# Ctrl+D
 
@@ -328,11 +328,11 @@ user_input = gets
 
 これを達成するために [`Colorize`](https://crystal-lang.org/api/latest/Colorize.html) モジュールを使いたいと思います。
 
-色付いた文字列を表示する、単純なアプリケーションを作ってみましょう。We will use a yellow font on a black background:
+色付いた文字列を表示する、単純なアプリケーションを作ってみましょう。黒の背景に黄色のフォントを使用します:
 
-!!!example "yellow_cli.cr"
-```crystal
-require "colorize"
+!!! example "yellow_cli.cr"
+    ```crystal
+    require "colorize"
 
     puts "#{"The Beatles".colorize(:yellow).on(:black)} App"
     ```
@@ -345,9 +345,9 @@ parser.banner = "#{"The Beatles".colorize(:yellow).on(:black)} App"
 
 ユーザーの入力を受け取る方のアプリケーションに、今回は`blink` (点滅)という*テキストの装飾*を追加してみましょう。
 
-!!!example "let_it_cli.cr"
-```crystal
-require "colorize"
+!!! example "let_it_cli.cr"
+    ```crystal
+    require "colorize"
 
     puts "Welcome to The Beatles Sing-Along version 1.0!"
     puts "Enter a phrase you want The Beatles to sing"
@@ -372,16 +372,16 @@ require "colorize"
 
 ## テスト
 
-As with any other application, at some point, we would like to [write tests](../guides/testing.md) for the different features.
+他のアプリケーションと同じように、ある時点で、さまざまな機能の[テストを書き](../guides/testing.md)たいと思うでしょう。
 
-現時点ではアプリケーションの各ロジックは`OptionParser`の内で実行されています。つまり、アプリケーション全体を実行することなしに、部分的にファイルを取り込むことができないのです。よって、まずはじめにオプションの解析部分と実際のロジックを分離するリファクタリングを行う必要があります。Once the refactoring is done, we could start testing the logic and including the file with the logic in the testing files we need. これを読者の課題とします。.
+現時点ではアプリケーションの各ロジックは`OptionParser`の内で実行されています。つまり、アプリケーション全体を実行することなしに、部分的にファイルを取り込むことができないのです。よって、まずはじめにオプションの解析部分と実際のロジックを分離するリファクタリングを行う必要があります。リファクタリングが完了したら、ロジックのテストを開始し、必要なテストファイルにロジックを含むファイルを含めることができます。これは読者の課題としましょう。これを読者の課題とします。.
 
 ## `Readline`と`NCurses`の利用
 
 よりリッチなCLI アプリケーションを構築しようと思ったとき、これらのライブラリが助けになります。`Readline`と`NCurses`という、2つのよく知られたライブラリです。
 
 [GNU Readline Library](http://www.gnu.org/software/readline/) で述べられているように、`Readline` はユーザーに対してコマンドライン編集機能を提供します。
-`Readline` has some great features: filename autocompletion out of the box; custom auto-completion method; keybinding, just to mention a few. それらの機能を使いたいのであれば [crystal-lang/crystal-readline](https://github.com/crystal-lang/crystal-readline) shard が `Readline` を簡単に扱うための API を提供しています。
+`Readline` は素晴らしく強力な機能があります。ボックス外でのファイル名の自動補完、自動補完方法のカスタマイズ、キーバインド変更というのはほんの一例です。それらの機能を使いたいのであれば [crystal-lang/crystal-readline](https://github.com/crystal-lang/crystal-readline) shard が `Readline` を簡単に扱うための API を提供しています。
 
 続いて、`NCurses`(New Curses) の紹介です。このライブラリは端末で_グラフィカルな_ユーザーインターフェースを開発することを可能にします。その名前が暗に示すように、これは`Curses`というライブラリの改良版です。`Curses` は Rouge というテキストベースのダンジョン探索アドベンチャーゲームのために開発されました。
 想像してみてください。`NCurses` Crystal で使うには[いくつもの shardls](https://crystalshards.org/shards/search?q=ncurses)がエコシステムには存在しています。


### PR DESCRIPTION
Close #133

Almost all translations are derived from #133, thus @ynott is noticed as co-author. However, code block indentation fixes are clearly wrong, and one translation is difficult to read (〜 `Nil` 値が (...) を 〜). I fixed them in this commit, and also updated translation memory.

@ynott Thank you for your contribution!